### PR TITLE
Retrieve authenticated user

### DIFF
--- a/backend/src/main/java/com/crave/backend/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/crave/backend/controller/AuthenticationController.java
@@ -1,11 +1,15 @@
 package com.crave.backend.controller;
 
+import com.crave.backend.model.Account;
 import com.crave.backend.model.auth.AuthenticationRequest;
 import com.crave.backend.model.auth.AuthenticationResponse;
 import com.crave.backend.model.auth.RegisterRequest;
+import com.crave.backend.service.AccountService;
 import com.crave.backend.service.AuthenticationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @CrossOrigin(origins = "http://localhost:3000")
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthenticationController {
     private final AuthenticationService authenticationService;
+    private final AccountService accountService;
 
     @PostMapping(path = "/register")
     public ResponseEntity<AuthenticationResponse> register(@RequestBody RegisterRequest request) {
@@ -33,5 +38,16 @@ public class AuthenticationController {
         } else {
             return ResponseEntity.badRequest().body(response);
         }
+    }
+
+    @GetMapping("/profile")
+    @ResponseBody
+    public ResponseEntity<?> viewUserProfile(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails != null) {
+            // userDetails contains information about the authenticated user
+            Account user = accountService.findByEmail(userDetails.getUsername()).orElse(null);
+            return ResponseEntity.ok(user);
+        }
+        return ResponseEntity.badRequest().body("User is not authenticated.");
     }
 }

--- a/backend/src/main/java/com/crave/backend/controller/UserOrderController.java
+++ b/backend/src/main/java/com/crave/backend/controller/UserOrderController.java
@@ -1,10 +1,15 @@
 package com.crave.backend.controller;
 
+import com.crave.backend.model.Account;
 import com.crave.backend.model.UserOrder;
+import com.crave.backend.service.AccountService;
 import com.crave.backend.service.UserOrderService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,17 +19,26 @@ import java.util.Optional;
 @CrossOrigin(origins = "http://localhost:3000")
 @RestController
 @RequestMapping(path = "userOrders")
+@RequiredArgsConstructor
 public class UserOrderController {
     private final UserOrderService userOrderService;
+    private final AccountService accountService;
 
-    @Autowired
-    public UserOrderController(UserOrderService userOrderService) {
-        this.userOrderService = userOrderService;
-    }
+//    // Need DB relationship between UserOrder and Account
+//    @GetMapping
+//    public List<UserOrder> getOrders() {
+//        return userOrderService.getOrders();
+//    }
 
     @GetMapping
-    public List<UserOrder> getOrders() {
-        return userOrderService.getOrders();
+    @ResponseBody
+    public ResponseEntity<?> getOrders(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails != null) {
+            // userDetails contains information about the authenticated user
+            Account user = accountService.findByEmail(userDetails.getUsername()).orElse(null);
+            return ResponseEntity.ok(user);
+        }
+        return ResponseEntity.badRequest().body("Unable to get the orders since user is not authenticated.");
     }
 
     @GetMapping(path = "/{id}")

--- a/backend/src/main/java/com/crave/backend/model/Account.java
+++ b/backend/src/main/java/com/crave/backend/model/Account.java
@@ -1,6 +1,7 @@
 package com.crave.backend.model;
 
 import com.crave.backend.enums.UserRole;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -36,7 +37,8 @@ public class Account implements UserDetails {
     private String password;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
-    @OneToMany(mappedBy = "user")
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Token> tokens;
 
     @Override

--- a/backend/src/main/java/com/crave/backend/model/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/crave/backend/model/auth/RegisterRequest.java
@@ -1,5 +1,6 @@
 package com.crave.backend.model.auth;
 
+import com.crave.backend.enums.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,4 +15,5 @@ public class RegisterRequest {
     private String lastName;
     private String email;
     private String password;
+    private UserRole userRole;
 }

--- a/backend/src/main/java/com/crave/backend/service/AccountService.java
+++ b/backend/src/main/java/com/crave/backend/service/AccountService.java
@@ -20,4 +20,8 @@ public class AccountService {
     public List<Account> getAccounts() {
         return accountRepository.findAll();
     }
+
+    public Optional<Account> findByEmail(String email) {
+        return accountRepository.findByEmail(email);
+    }
 }

--- a/backend/src/main/java/com/crave/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/com/crave/backend/service/AuthenticationService.java
@@ -41,7 +41,7 @@ public class AuthenticationService {
                 .lastName(request.getLastName())
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
-                .userRole(UserRole.USER)
+                .userRole(request.getUserRole())
                 .build();
 
         var savedUser = accountRepository.save(user);


### PR DESCRIPTION
- Fix bug with Account Get request resulting into infinite loops and circular references due to the DB relationship with Account and Token. **Solution**:  add the `@JSONIgnore` on the Account model.
- Create a new endpoint for retrieving the user (auth/profile). You should provide the bearer token in the header.
- Update Registration to include the USER_ROLE when registering.

#100 