### PR TITLE
Ingredient Entity

### DIFF
--- a/backend/src/main/java/com/crave/backend/config/CraveConfig.java
+++ b/backend/src/main/java/com/crave/backend/config/CraveConfig.java
@@ -1,7 +1,11 @@
 package com.crave.backend.config;
 
+import com.crave.backend.model.Dish;
+import com.crave.backend.model.Ingredient;
 import com.crave.backend.model.Restaurant;
 import com.crave.backend.repository.AccountRepository;
+import com.crave.backend.repository.DishRepository;
+import com.crave.backend.repository.IngredientRepository;
 import com.crave.backend.repository.RestaurantRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,13 +22,40 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class CraveConfig {
     private final AccountRepository accountRepository;
-    
+
+    @Bean
+    CommandLineRunner commandLineRunner(RestaurantRepository restaurantRepository, IngredientRepository ingredientRepository) {
+        return args -> {
+            // TODO: remove fake data
+            // Restaurants
+            Restaurant mcdo = new Restaurant("McDonalds", "Kildonan 11", 4.5, "testImage");
+            Restaurant burgerKing = new Restaurant("Burger King", "Northgate 22", 4.3, "testImage");
+            restaurantRepository.saveAll(List.of(mcdo, burgerKing));
+
+            //Ingredients
+            Ingredient ingredient1 = Ingredient.builder()
+                    .name("beef")
+                    .tag("beef")
+                    .quantity(2)
+                    .build();
+
+            Ingredient ingredient2 = Ingredient.builder()
+                    .name("garlic")
+                    .tag("garlic")
+                    .quantity(3)
+                    .build();
+            ingredientRepository.saveAll(List.of(ingredient1, ingredient2));
+
+        };
+    }
+
     @Bean
     public UserDetailsService userDetailsService() {
         return username -> accountRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException("User does not exist"));

--- a/backend/src/main/java/com/crave/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/crave/backend/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
             "/auth/**",
             "/accounts",
             "/restaurants",
+            "/dishes/**",
+            "/ingredients/**"
     };
 
     @Bean

--- a/backend/src/main/java/com/crave/backend/controller/DishController.java
+++ b/backend/src/main/java/com/crave/backend/controller/DishController.java
@@ -1,12 +1,12 @@
 package com.crave.backend.controller;
 
 import com.crave.backend.model.Dish;
+import com.crave.backend.model.Restaurant;
 import com.crave.backend.service.DishService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -14,14 +14,26 @@ import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
 @RequestMapping("/dishes")
+@RequiredArgsConstructor
 public class DishController {
     private final DishService dishService;
 
-    public DishController(DishService dishService) {
-        this.dishService = dishService;
+    @GetMapping
+    public ResponseEntity<List<Dish>> getDishes() {
+        return ok(dishService.getDishes());
     }
 
-    @GetMapping
+    @PostMapping(path = "/create")
+    public ResponseEntity<?> createDish(@RequestBody Dish dish) {
+        try {
+            Dish newDish = dishService.createDish(dish);
+            return new ResponseEntity<>(newDish, HttpStatus.CREATED);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @GetMapping(path = "/byTags")
     public ResponseEntity<List<Dish>> getByTags(@RequestParam(value = "tags", required = false) List<String> tags) {
         return ok(dishService.getByTags(tags));
     }

--- a/backend/src/main/java/com/crave/backend/controller/IngredientController.java
+++ b/backend/src/main/java/com/crave/backend/controller/IngredientController.java
@@ -1,0 +1,30 @@
+package com.crave.backend.controller;
+
+import com.crave.backend.model.Ingredient;
+import com.crave.backend.service.IngredientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequestMapping("/ingredients")
+@RequiredArgsConstructor
+public class IngredientController {
+    private final IngredientService ingredientService;
+
+    @GetMapping
+    public ResponseEntity<List<Ingredient>> getIngredients() {
+        return ok(ingredientService.getIngredients());
+    }
+
+    @PostMapping(path = "/create")
+    public ResponseEntity<Ingredient> createIngredient(@RequestBody Ingredient ingredient) {
+        Ingredient newIngredient = ingredientService.createIngredient(ingredient);
+        return new ResponseEntity<>(newIngredient, HttpStatus.CREATED);
+    }
+}

--- a/backend/src/main/java/com/crave/backend/model/Dish.java
+++ b/backend/src/main/java/com/crave/backend/model/Dish.java
@@ -1,7 +1,10 @@
 package com.crave.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @Table
@@ -10,7 +13,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@RequiredArgsConstructor
+@Builder
 public class Dish {
     @Id
     @SequenceGenerator(
@@ -23,11 +26,22 @@ public class Dish {
             generator = "dish_sequence"
     )
     private Long id;
-    @NonNull
     private String name;
-    @NonNull
+    private String description;
     private String tag;
     private String imageUrl;
     private float price;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "dish_ingredients",
+            joinColumns = @JoinColumn(name = "dish_id")
+    )
+    @Column(name = "ingredient_id")
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private List<Long> ingredientIds;
+
+    // Transient field to load ingredients during retrieval
+    @Transient
+    private List<Ingredient> ingredients;
 }

--- a/backend/src/main/java/com/crave/backend/model/Ingredient.java
+++ b/backend/src/main/java/com/crave/backend/model/Ingredient.java
@@ -1,0 +1,32 @@
+package com.crave.backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Ingredient {
+    @Id
+    @SequenceGenerator(
+            name = "ingredient_sequence",
+            sequenceName = "ingredient_sequence",
+            allocationSize = 1
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "ingredient_sequence"
+    )
+    private Long id;
+    private String name;
+    private String tag;
+    private double quantity;
+}

--- a/backend/src/main/java/com/crave/backend/repository/IngredientRepository.java
+++ b/backend/src/main/java/com/crave/backend/repository/IngredientRepository.java
@@ -1,0 +1,7 @@
+package com.crave.backend.repository;
+
+import com.crave.backend.model.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+}

--- a/backend/src/main/java/com/crave/backend/service/DishService.java
+++ b/backend/src/main/java/com/crave/backend/service/DishService.java
@@ -1,16 +1,39 @@
 package com.crave.backend.service;
 
 import com.crave.backend.model.Dish;
+import com.crave.backend.model.Ingredient;
 import com.crave.backend.repository.DishRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.crave.backend.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class DishService {
-    @Autowired
-    private DishRepository dishRepository;
+    private final DishRepository dishRepository;
+    private final IngredientRepository ingredientRepository;
+
+    public List<Dish> getDishes() {
+        return dishRepository.findAll();
+    }
+
+    public Dish createDish(Dish dish) {
+        List<Long> ingredientIds = dish.getIngredientIds();
+
+        // Check if id of ingredient exists
+        for (Long ingredientId : ingredientIds) {
+            if (!ingredientRepository.existsById(ingredientId)) {
+                throw new IllegalArgumentException("Ingredient with ID " + ingredientId + " does not exist");
+            }
+        }
+
+        List<Ingredient> ingredients = ingredientRepository.findAllById(dish.getIngredientIds());
+        dish.setIngredients(ingredients);
+
+        return dishRepository.save(dish);
+    }
 
     public List<Dish> getByTags(List<String> tags) {
         return dishRepository.findByTagIn(tags);

--- a/backend/src/main/java/com/crave/backend/service/IngredientService.java
+++ b/backend/src/main/java/com/crave/backend/service/IngredientService.java
@@ -1,0 +1,22 @@
+package com.crave.backend.service;
+
+import com.crave.backend.model.Ingredient;
+import com.crave.backend.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientService {
+    private final IngredientRepository ingredientRepository;
+
+    public List<Ingredient> getIngredients() {
+        return ingredientRepository.findAll();
+    }
+
+    public Ingredient createIngredient(Ingredient ingredient) {
+        return ingredientRepository.save(ingredient);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,13 +3,13 @@ spring:
     # Use this for docker environment
     url: jdbc:postgresql://crave-postgres-container:5432/crave
     # Use this for local
-    # url: jdbc:postgresql://localhost:5432/crave 
+    # url: jdbc:postgresql://localhost:5432/crave
     username: postgres
     password: crave
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/backend/src/test/java/com/crave/backend/unit/DishTest.java
+++ b/backend/src/test/java/com/crave/backend/unit/DishTest.java
@@ -1,0 +1,86 @@
+package com.crave.backend.unit;
+
+import com.crave.backend.model.Dish;
+import com.crave.backend.model.Ingredient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DishTest {
+    private List<Long> ingredientIds;
+    private Dish dish;
+
+    @BeforeEach
+    public void setUp() {
+        ingredientIds = new ArrayList<>();
+        Ingredient ingredient;
+
+        ingredient = Ingredient.builder()
+                .id(100l)
+                .name("beef")
+                .tag("beef")
+                .quantity(2)
+                .build();
+        ingredientIds.add(ingredient.getId());
+
+        ingredient = Ingredient.builder()
+                .id(101l)
+                .name("garlic")
+                .tag("garlic")
+                .quantity(3)
+                .build();
+
+        ingredientIds.add(ingredient.getId());
+
+        dish = Dish.builder()
+                .id(1l)
+                .name("Burger")
+                .description("Burger description")
+                .tag("beef")
+                .imageUrl("some-image-url")
+                .price(14.99f)
+                .ingredientIds(ingredientIds)
+                .build();
+
+    }
+
+    @Test
+    void testGetters() {
+        assertEquals(1L, dish.getId());
+        assertEquals("Burger", dish.getName());
+        assertEquals("Burger description", dish.getDescription());
+        assertEquals("beef", dish.getTag());
+        assertEquals("some-image-url", dish.getImageUrl());
+        assertEquals(14.99f, dish.getPrice());
+
+        // Ingredients
+        List<Long> actualList = dish.getIngredientIds();
+        assertEquals(100l, actualList.get(0));
+
+        assertEquals(101l, actualList.get(1));
+    }
+
+    @Test
+    void testSetters() {
+        dish.setId(2L);
+        dish.setName("Chicken Alfredo");
+        dish.setDescription("Chicken Alfredo description");
+        dish.setTag("chicken");
+        dish.setImageUrl("some-image-url-updated");
+        dish.setPrice(14.99f);
+        dish.setIngredientIds(new ArrayList<>());
+
+        assertEquals(2L, dish.getId());
+        assertEquals("Chicken Alfredo", dish.getName());
+        assertEquals("Chicken Alfredo description", dish.getDescription());
+        assertEquals("chicken", dish.getTag());
+        assertEquals("some-image-url-updated", dish.getImageUrl());
+        assertEquals(14.99f, dish.getPrice());
+
+        assertEquals(0, dish.getIngredientIds().size());
+    }
+}

--- a/backend/src/test/java/com/crave/backend/unit/IngredientTest.java
+++ b/backend/src/test/java/com/crave/backend/unit/IngredientTest.java
@@ -1,0 +1,43 @@
+package com.crave.backend.unit;
+
+import com.crave.backend.model.Ingredient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IngredientTest {
+    private Ingredient ingredient;
+    
+    @BeforeEach
+    public void setUp() {
+
+        ingredient = Ingredient.builder()
+                .id(1l)
+                .name("Garlic")
+                .tag("garlic tag")
+                .quantity(2)
+                .build();
+    }
+
+    @Test
+    void testGetters() {
+        assertEquals(1L, ingredient.getId());
+        assertEquals("Garlic", ingredient.getName());
+        assertEquals("garlic tag", ingredient.getTag());
+        assertEquals(2, ingredient.getQuantity());
+    }
+
+    @Test
+    void testSetters() {
+        ingredient.setId(2L);
+        ingredient.setName("beef");
+        ingredient.setTag("beef tag");
+        ingredient.setQuantity(1);
+
+        assertEquals(2L, ingredient.getId());
+        assertEquals("beef", ingredient.getName());
+        assertEquals("beef tag", ingredient.getTag());
+        assertEquals(1, ingredient.getQuantity());
+    }
+}


### PR DESCRIPTION
- Setup a new entity for the ingredients along with service, repository and controller.
- Modify Dish to have a list of ingredients (many to many relationship)
- Dish creation requires an existing ingredient ID.
- Setup unit tests for Dish and Ingredient models.
- Update application.yml to clean the database whenever the app starts.
- Include fake data for ingredients in the crave config.

## New API endpoints:


### Ingredients
**GET Request** for retrieving a list of ingredients: http://localhost:8080/ingredients

**POST Request** for adding a new ingredient: http://localhost:8080/ingredients/create
JSON body payload sample 
```
{
    "name": "beef",
    "tag":"tag1",
    "quantity": 2
}
```
### Dishes
**Get Request** for retrieving a list of dishes: http://localhost:8080/dishes

**POST Request** for adding a new dish: http://localhost:8080/dishes/create
JSON body payload 
```
{
   {
    "name": "dish2",
    "description": "Description2",
    "tag": "tag2",
    "imageUrl": "test-url2",
    "price": 12.99,
    "ingredientIds": [
        1, // This ingredient id should exist
     ]
   }
}
```


#113 #112