### PR TITLE
DB relationship for Dish, Comment,  Account

### DIFF
--- a/backend/src/main/java/com/crave/backend/config/CraveConfig.java
+++ b/backend/src/main/java/com/crave/backend/config/CraveConfig.java
@@ -1,13 +1,16 @@
 package com.crave.backend.config;
 
+import com.crave.backend.enums.UserRole;
 import com.crave.backend.model.Dish;
 import com.crave.backend.model.Ingredient;
 import com.crave.backend.model.Restaurant;
+import com.crave.backend.model.auth.RegisterRequest;
 import com.crave.backend.repository.AccountRepository;
 import com.crave.backend.repository.DishRepository;
 import com.crave.backend.repository.IngredientRepository;
 import com.crave.backend.repository.RestaurantRepository;
 
+import com.crave.backend.service.AuthenticationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -31,7 +34,11 @@ public class CraveConfig {
     private final AccountRepository accountRepository;
 
     @Bean
-    CommandLineRunner commandLineRunner(RestaurantRepository restaurantRepository, IngredientRepository ingredientRepository) {
+    CommandLineRunner commandLineRunner(
+            RestaurantRepository restaurantRepository,
+            IngredientRepository ingredientRepository,
+            DishRepository dishRepository,
+            AuthenticationService authenticationService) {
         return args -> {
             // TODO: remove fake data
             // Restaurants
@@ -52,6 +59,39 @@ public class CraveConfig {
                     .quantity(3)
                     .build();
             ingredientRepository.saveAll(List.of(ingredient1, ingredient2));
+
+            List<Ingredient> dbIgredients = ingredientRepository.findAll();
+
+            // Dish
+            Dish dish = Dish.builder()
+                    .name("Beef Wellington")
+                    .description("Description for beef wellington")
+                    .tag("tag1")
+                    .imageUrl("beef-wellington-img")
+                    .ingredientIds(List.of(dbIgredients.get(0).getId(), dbIgredients.get(1).getId()))
+                    .price(25.99f)
+                    .build();
+            dishRepository.save(dish);
+            
+            // Account registrations
+            RegisterRequest userRegistration = RegisterRequest.builder()
+                    .firstName("User")
+                    .lastName("Demo")
+                    .email("userdemo@gmail.com")
+                    .password("demo")
+                    .userRole(UserRole.USER)
+                    .build();
+
+            RegisterRequest adminRegistration = RegisterRequest.builder()
+                    .firstName("Admin")
+                    .lastName("Demo")
+                    .email("admindemo@gmail.com")
+                    .password("demo")
+                    .userRole(UserRole.ADMIN)
+                    .build();
+
+            authenticationService.register(userRegistration);
+            authenticationService.register(adminRegistration);
 
         };
     }

--- a/backend/src/main/java/com/crave/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/crave/backend/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
             "/accounts",
             "/restaurants",
             "/dishes/**",
-            "/ingredients/**"
+            "/ingredients/**",
+            "/comments/**"
     };
 
     @Bean

--- a/backend/src/main/java/com/crave/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/crave/backend/controller/CommentController.java
@@ -1,35 +1,49 @@
 package com.crave.backend.controller;
 
+import com.crave.backend.model.Account;
 import com.crave.backend.model.Comment;
+import com.crave.backend.model.Dish;
+import com.crave.backend.service.AccountService;
 import com.crave.backend.service.CommentService;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.crave.backend.service.DishService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
-@RequestMapping("dishes")
+@RequestMapping("comments")
+@RequiredArgsConstructor
 public class CommentController {
     private final CommentService commentService;
+    private final AccountService accountService;
+    private final DishService dishService;
 
-    @Autowired
-    public CommentController(CommentService commentService) {
-        this.commentService = commentService;
+    @GetMapping(path = "/{dishId}")
+    public ResponseEntity<?> getComments(@PathVariable Long dishId) {
+        Dish dish = dishService.findDish(dishId);
+        if (dish != null) {
+            return ok(commentService.getComments(dishId));
+        } else {
+            return ResponseEntity.badRequest().body("Dish with id " + dishId + " does not exist");
+        }
     }
 
-    @GetMapping("/{dishId}/comments")
-    public ResponseEntity<List<Comment>> getComments(@PathVariable Long dishId) {
-        return ok(commentService.getComments(dishId));
-    }
+    @PostMapping(path = "/create/{dishId}")
+    public ResponseEntity<?> createCommentOnDishId(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long dishId, @RequestBody Comment comment) {
+        if (userDetails != null) {
+            // userDetails contains information about the authenticated user
+            Account user = accountService.findByEmail(userDetails.getUsername()).orElseThrow(() -> new EntityNotFoundException("User with email " + userDetails.getUsername() + "does not exist"));
 
-    @PostMapping("/{dishId}/comments")
-    public ResponseEntity<Comment> createComment(@RequestBody Comment comment) {
-        Comment newComment = commentService.createComment(comment);
-        return new ResponseEntity<>(newComment, HttpStatus.CREATED);
+            Comment newComment = commentService.createComment(user, dishId, comment);
+            return new ResponseEntity<>(newComment, HttpStatus.CREATED);
+        }
+        return ResponseEntity.badRequest().body("User has to be authenticated in order to make a comment.");
 
     }
 }

--- a/backend/src/main/java/com/crave/backend/controller/DishController.java
+++ b/backend/src/main/java/com/crave/backend/controller/DishController.java
@@ -1,7 +1,6 @@
 package com.crave.backend.controller;
 
 import com.crave.backend.model.Dish;
-import com.crave.backend.model.Restaurant;
 import com.crave.backend.service.DishService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/crave/backend/model/Account.java
+++ b/backend/src/main/java/com/crave/backend/model/Account.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -40,6 +41,10 @@ public class Account implements UserDetails {
     @JsonIgnore
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Token> tokens;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/backend/src/main/java/com/crave/backend/model/Comment.java
+++ b/backend/src/main/java/com/crave/backend/model/Comment.java
@@ -6,15 +6,10 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_Id", "dish_Id"})
-})
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@RequiredArgsConstructor
 @Builder
 public class Comment {
     @Id
@@ -28,12 +23,12 @@ public class Comment {
             generator = "comment_sequence"
     )
     private Long id;
-    @NonNull
-    private Long dish_id;
-    @NonNull
-    private Long user_id;
-    @NonNull
     private String content;
-    @NonNull
     private LocalDateTime createdAt;
+    @ManyToOne
+    @JoinColumn(name = "dish_id")
+    private Dish dish;
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
 }

--- a/backend/src/main/java/com/crave/backend/model/Dish.java
+++ b/backend/src/main/java/com/crave/backend/model/Dish.java
@@ -1,16 +1,17 @@
 package com.crave.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -44,4 +45,8 @@ public class Dish {
     // Transient field to load ingredients during retrieval
     @Transient
     private List<Ingredient> ingredients;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "dish", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 }

--- a/backend/src/main/java/com/crave/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/crave/backend/repository/CommentRepository.java
@@ -2,8 +2,12 @@ package com.crave.backend.repository;
 
 import com.crave.backend.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findCommentsByDishId(Long dishId);
 }

--- a/backend/src/main/java/com/crave/backend/service/CommentService.java
+++ b/backend/src/main/java/com/crave/backend/service/CommentService.java
@@ -1,56 +1,36 @@
 package com.crave.backend.service;
 
+import com.crave.backend.model.Account;
 import com.crave.backend.model.Comment;
+import com.crave.backend.model.Dish;
 import com.crave.backend.repository.CommentRepository;
+import com.crave.backend.repository.DishRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
-
-    @Autowired
-    public CommentService(CommentRepository commentRepository) {
-        this.commentRepository = commentRepository;
-    }
+    private final DishRepository dishRepository;
 
     public List<Comment> getComments(long dishId) {
-        return commentRepository.findAll().stream()
-                .filter(x -> x.getDish_id() == dishId)
-                .toList();
+        return commentRepository.findCommentsByDishId(dishId);
     }
 
-    public Optional<Comment> getCommentById(Long id) {
-        return commentRepository.findById(id);
-    }
+    public Comment createComment(Account account, Long dishId, Comment comment) {
+        Dish dish = dishRepository.findById(dishId).orElseThrow(() -> new EntityNotFoundException("Dish with id " + dishId + " not found"));
 
-    public Comment createComment(Comment comment) {
+        comment.setDish(dish);
+        comment.setAccount(account);
+        comment.setCreatedAt(LocalDateTime.now());
         return commentRepository.save(comment);
     }
 
-    public Comment updateComment(Comment existingComment, Comment updatedComment) {
-
-        if (existingComment != null) {
-            existingComment.setContent(updatedComment.getContent());
-            commentRepository.save(existingComment);
-        }
-
-        return existingComment;
-    }
-
-    public void deleteCommentById(Long id) {
-        commentRepository.deleteById(id);
-    }
-
-    public Comment findById(Long id) {
-        Optional<Comment> comment = commentRepository.findById(id);
-        return comment.orElse(null);
-    }
-
-    public boolean exists(Long id) {
-        return commentRepository.findById(id).isPresent();
-    }
 }

--- a/backend/src/main/java/com/crave/backend/service/DishService.java
+++ b/backend/src/main/java/com/crave/backend/service/DishService.java
@@ -4,9 +4,11 @@ import com.crave.backend.model.Dish;
 import com.crave.backend.model.Ingredient;
 import com.crave.backend.repository.DishRepository;
 import com.crave.backend.repository.IngredientRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -16,7 +18,13 @@ public class DishService {
     private final IngredientRepository ingredientRepository;
 
     public List<Dish> getDishes() {
-        return dishRepository.findAll();
+        List<Dish> dishes = dishRepository.findAll();
+        for (Dish dish : dishes) {
+            List<Ingredient> ingredients = ingredientRepository.findAllById(dish.getIngredientIds());
+            dish.setIngredients(ingredients);
+        }
+
+        return dishes;
     }
 
     public Dish createDish(Dish dish) {
@@ -33,6 +41,10 @@ public class DishService {
         dish.setIngredients(ingredients);
 
         return dishRepository.save(dish);
+    }
+
+    public Dish findDish(Long id) {
+        return dishRepository.findById(id).orElse(null);
     }
 
     public List<Dish> getByTags(List<String> tags) {

--- a/backend/src/test/java/com/crave/backend/unit/CommentTest.java
+++ b/backend/src/test/java/com/crave/backend/unit/CommentTest.java
@@ -1,45 +1,83 @@
 package com.crave.backend.unit;
 
+import com.crave.backend.enums.UserRole;
+import com.crave.backend.model.Account;
 import com.crave.backend.model.Comment;
+import com.crave.backend.model.Dish;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CommentTest {
     private Comment comment;
+    private Dish dish;
+    private Account user;
 
     @BeforeEach
     public void setUp() {
+        user = Account.builder()
+                .id(1l)
+                .firstName("Dushane")
+                .lastName("Hill")
+                .email("dhill@gmail.co.uk")
+                .password("idkruhfaminnit")
+                .userRole(UserRole.USER)
+                .build();
+
+        dish = Dish.builder()
+                .id(1l)
+                .name("Burger")
+                .description("Burger description")
+                .tag("beef")
+                .imageUrl("some-image-url")
+                .price(14.99f)
+                .ingredientIds(new ArrayList<>())
+                .build();
+
         comment = Comment.builder()
                 .id(1L)
-                .dish_id(1L)
-                .user_id(1L)
                 .content("Comment description ......")
-                .createdAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.of(2023, Month.NOVEMBER, 10, 12, 30))
+                .dish(dish)
+                .account(user)
                 .build();
     }
 
     @Test
     void testGetters() {
         assertEquals(1L, comment.getId());
-        assertEquals(1L, comment.getDish_id());
-        assertEquals(1L, comment.getUser_id());
         assertEquals("Comment description ......", comment.getContent());
+        assertEquals(LocalDateTime.of(2023, Month.NOVEMBER, 10, 12, 30), comment.getCreatedAt());
+
+        // Dish
+        assertEquals(1l, comment.getDish().getId());
+        assertEquals("Burger", comment.getDish().getName());
+        //Account
+        assertEquals(1l, comment.getAccount().getId());
+        assertEquals("dhill@gmail.co.uk", comment.getAccount().getEmail());
     }
 
     @Test
     void testSetters() {
         comment.setId(2L);
-        comment.setDish_id(2L);
-        comment.setUser_id(2L);
         comment.setContent("Updated comment");
+        comment.setCreatedAt(LocalDateTime.of(2023, Month.DECEMBER, 24, 23, 59));
+        comment.setDish(null);
+        comment.setAccount(null);
 
         assertEquals(2L, comment.getId());
-        assertEquals(2L, comment.getDish_id());
-        assertEquals(2L, comment.getUser_id());
         assertEquals("Updated comment", comment.getContent());
+        assertEquals(LocalDateTime.of(2023, Month.DECEMBER, 24, 23, 59), comment.getCreatedAt());
+
+        // Dish
+        assertNull(comment.getDish());
+        //Account
+        assertNull(comment.getAccount());
     }
 }

--- a/backend/src/test/java/com/crave/backend/unit/DishTest.java
+++ b/backend/src/test/java/com/crave/backend/unit/DishTest.java
@@ -1,41 +1,46 @@
 package com.crave.backend.unit;
 
+import com.crave.backend.model.Comment;
 import com.crave.backend.model.Dish;
 import com.crave.backend.model.Ingredient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DishTest {
-    private List<Long> ingredientIds;
     private Dish dish;
 
     @BeforeEach
     public void setUp() {
-        ingredientIds = new ArrayList<>();
-        Ingredient ingredient;
-
-        ingredient = Ingredient.builder()
+        // Setup ingredients
+        Ingredient beefIngredient = Ingredient.builder()
                 .id(100l)
                 .name("beef")
                 .tag("beef")
                 .quantity(2)
                 .build();
-        ingredientIds.add(ingredient.getId());
 
-        ingredient = Ingredient.builder()
+        Ingredient garlicIngredient = Ingredient.builder()
                 .id(101l)
                 .name("garlic")
                 .tag("garlic")
                 .quantity(3)
                 .build();
 
-        ingredientIds.add(ingredient.getId());
+        // Setup comment
+        Comment comment = Comment.builder()
+                .id(201l)
+                .content("Dish comment")
+                .createdAt(LocalDateTime.of(2023, Month.NOVEMBER, 10, 12, 30))
+                .build();
 
+        // Setup dish
         dish = Dish.builder()
                 .id(1l)
                 .name("Burger")
@@ -43,7 +48,9 @@ public class DishTest {
                 .tag("beef")
                 .imageUrl("some-image-url")
                 .price(14.99f)
-                .ingredientIds(ingredientIds)
+                .ingredientIds(List.of(beefIngredient.getId(), garlicIngredient.getId()))
+                .ingredients(List.of(beefIngredient, garlicIngredient))
+                .comments(List.of(comment))
                 .build();
 
     }
@@ -57,11 +64,22 @@ public class DishTest {
         assertEquals("some-image-url", dish.getImageUrl());
         assertEquals(14.99f, dish.getPrice());
 
-        // Ingredients
-        List<Long> actualList = dish.getIngredientIds();
-        assertEquals(100l, actualList.get(0));
+        // Ingredient Ids
+        List<Long> ingredientIds = dish.getIngredientIds();
+        assertEquals(100l, ingredientIds.get(0));
+        assertEquals(101l, ingredientIds.get(1));
 
-        assertEquals(101l, actualList.get(1));
+        // Ingredient objects
+        List<Ingredient> ingredients = dish.getIngredients();
+        assertEquals(100l, ingredients.get(0).getId());
+        assertEquals("beef", ingredients.get(0).getName());
+
+        assertEquals(101l, ingredients.get(1).getId());
+        assertEquals("garlic", ingredients.get(1).getName());
+
+        // Comments
+        assertEquals(201, dish.getComments().get(0).getId());
+        assertEquals("Dish comment", dish.getComments().get(0).getContent());
     }
 
     @Test
@@ -73,6 +91,8 @@ public class DishTest {
         dish.setImageUrl("some-image-url-updated");
         dish.setPrice(14.99f);
         dish.setIngredientIds(new ArrayList<>());
+        dish.setIngredients(new ArrayList<>());
+        dish.setComments(new ArrayList<>());
 
         assertEquals(2L, dish.getId());
         assertEquals("Chicken Alfredo", dish.getName());
@@ -82,5 +102,7 @@ public class DishTest {
         assertEquals(14.99f, dish.getPrice());
 
         assertEquals(0, dish.getIngredientIds().size());
+        assertEquals(0, dish.getIngredients().size());
+        assertEquals(0, dish.getComments().size());
     }
 }


### PR DESCRIPTION
- Create demo accounts for USER and ADMIN roles.
- Add 1 to many relationship between Dish and Comments.
- Add 1 to many relationship between Account and Comments.
- Adjust CommentController such that you can retrieve comments based on the dishId if it exists, and add a comment on a dish that exists only if you are logged in as a user or admin.
- Fix bug in retreiving the dishes as ingredients is always null.
- Remove outdated functionalities for updating/deleting comments. Will eventually add these back and satisfy the relationship for dish and account

## Comment API endpoint
GET request for list of comments: http://localhost:8080/comments
- Does not need to be logged in to access this endpoint

POST request for making a comment on a dish: http://localhost:8080/comments/create/{dishId}
- Ensure that you are logged in as a user or admin to create a comment (Add the login token on the bearer token)
- Ensure that dishId you provide exists. Will give you a message that the id of the dish does not exist otherwise.

#113 #112 
