### PR TITLE
Setup different .yml files

### DIFF
--- a/backend/src/main/java/com/crave/backend/config/CraveConfig.java
+++ b/backend/src/main/java/com/crave/backend/config/CraveConfig.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -23,8 +24,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.IntStream;
 
 @Configuration
@@ -34,15 +35,19 @@ public class CraveConfig {
 
     @Bean
     CommandLineRunner commandLineRunner(
+            Environment environment,
             RestaurantRepository restaurantRepository,
             IngredientRepository ingredientRepository,
             DishRepository dishRepository,
             AuthenticationService authenticationService) {
         return args -> {
-            seedRestaurants(restaurantRepository);
-            seedIngredients(ingredientRepository);
-            seedDishes(ingredientRepository, dishRepository);
-            seedAccounts(authenticationService);
+            if (Arrays.asList(environment.getActiveProfiles()).contains("local")
+                    || Arrays.asList(environment.getActiveProfiles()).contains("docker")) {
+                seedRestaurants(restaurantRepository);
+                seedIngredients(ingredientRepository);
+                seedDishes(ingredientRepository, dishRepository);
+                seedAccounts(authenticationService);
+            }
         };
     }
 

--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -1,12 +1,13 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    # Use this for docker environment
+    url: jdbc:postgresql://crave-postgres-container:5432/crave
+    username: postgres
+    password: crave
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,12 +1,12 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
+    url: jdbc:postgresql://localhost:5432/crave
+    username: postgres
+    password: crave
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/backend/src/test/java/com/crave/backend/integration/IngredientControllerTest.java
+++ b/backend/src/test/java/com/crave/backend/integration/IngredientControllerTest.java
@@ -33,7 +33,7 @@ public class IngredientControllerTest {
         ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
 
         assertEquals(OK, response.getStatusCode());
-        assertEquals(2, response.getBody().size()); // DB has 2 ingredients by default. Look at CraveConfig
+        assertEquals(0, response.getBody().size()); // DB has 2 ingredients by default. Look at CraveConfig
     }
 
     @Test

--- a/backend/src/test/java/com/crave/backend/integration/IngredientServiceTest.java
+++ b/backend/src/test/java/com/crave/backend/integration/IngredientServiceTest.java
@@ -25,9 +25,7 @@ public class IngredientServiceTest {
     @Test
     public void testGetIngredients() {
         List<Ingredient> ingredients = ingredientService.getIngredients();
-
-        // Has 2 ingredients based on the craveConfig (Fake data also applies to test db)
-        assertEquals(2, ingredients.size());
+        assertEquals(0, ingredients.size());
     }
 
     @Test
@@ -43,5 +41,8 @@ public class IngredientServiceTest {
         assertEquals(ingredient.getName(), createdIngredient.getName());
         assertEquals(ingredient.getTag(), createdIngredient.getTag());
         assertEquals(ingredient.getQuantity(), createdIngredient.getQuantity());
+
+        List<Ingredient> ingredients = ingredientService.getIngredients();
+        assertEquals(1, ingredients.size());
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: "development"
+      SPRING_PROFILES_ACTIVE: "docker"
     volumes:
       - backend-data:/app/data
 
@@ -24,10 +24,10 @@ services:
     image: postgres:latest
     ports:
       - "5432:5432"
-    environment: # Ask the contributors for the .env file
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: crave
+      POSTGRES_DB: crave
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -2,7 +2,7 @@ export const REQUEST_TIMEOUT = 1000;
 
 const PORT = 8080;
 export const SOCKET_URL = `ws://localhost:${PORT}/ws`;
-export const BASE_URL = `http://localhost:${PORT}`;
+export const BASE_URL = process.env.REACT_APP_API_URL || `http://localhost:${PORT}`;
 export const endpoint = {
 	TAGS: '/tags',
 	LOGIN: '/auth/login',


### PR DESCRIPTION
- Create different .yml files for different environment.
- application-docker.yml is used when running the project through docker-compose.
- application-local.yml is used when running the project locally.
- application.yml is used for production
- Update CraveConfig file such that it only creates fake data on local and on docker environment

On your application configuration (Intellij), Add this following code in the VM options to run the `application-local.yml`
```
-Dspring.profiles.active=local
```
![image](https://github.com/jablue-12/crave/assets/59758243/14dc170a-191d-481b-8f66-e08093140842)


#97